### PR TITLE
Expose service annotations for helm chart

### DIFF
--- a/deploy/k8s/chart/templates/service.yaml
+++ b/deploy/k8s/chart/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     {{- include "cortex-tenant.labels" . | nindent 4 }}
   name: {{ include "cortex-tenant.fullname" . }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/chart/values.schema.json
+++ b/deploy/k8s/chart/values.schema.json
@@ -64,6 +64,12 @@
             "LoadBalancer"
           ]
         },
+
+        "annotations": {
+        "type": "object",
+        "title": "Annotations",
+        "description": "Annotations for the service"
+        },
         "port": {
           "type": "integer",
           "title": "Port",

--- a/deploy/k8s/chart/values.yaml
+++ b/deploy/k8s/chart/values.yaml
@@ -17,6 +17,7 @@ image:
   #   - myRegistryKeySecretName
 
 service:
+  annotations: {}
   # -- The type of service
   type: ClusterIP
   # -- The port on which the service listens for traffic


### PR DESCRIPTION
## Description
This just adds a section to expose annotations for the cortex-proxy service. This will allow people, like me :P, to use aws-lb-controller to automatically expose it to a VPC via a nlb/alb/etc as well as use externaldns to define an route53 entry etc. 

## example:
* annotations.yaml
```
service:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: cortex-tenant.internaldns.io
    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Name=cortex-tenant, Service=mimir, , Environment=staging, Role=reverse-proxy
    service.beta.kubernetes.io/aws-load-balancer-name: mimir-ctxproxy  # Name the NLB
```

* without annotations.yaml:
```
# Source: cortex-tenant/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    helm.sh/chart: cortex-tenant-0.8.0
    app.kubernetes.io/name: cortex-tenant
    app.kubernetes.io/instance: cortex-proxy
    app.kubernetes.io/version: "1.13.0"
    app.kubernetes.io/managed-by: Helm
  name: cortex-proxy-cortex-tenant
  annotations: {}
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 8080
      targetPort: 8080
      protocol: TCP
  selector:
    app.kubernetes.io/name: cortex-tenant
    app.kubernetes.io/instance: cortex-proxy
```

* with annotations.yaml:
```
# Source: cortex-tenant/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    helm.sh/chart: cortex-tenant-0.8.0
    app.kubernetes.io/name: cortex-tenant
    app.kubernetes.io/instance: cortex-proxy
    app.kubernetes.io/version: "1.13.0"
    app.kubernetes.io/managed-by: Helm
  name: cortex-proxy-cortex-tenant
  annotations:
      external-dns.alpha.kubernetes.io/hostname: cortex-tenant.internaldns.io
    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Name=cortex-tenant, Service=mimir, , Environment=staging, Role=reverse-proxy
    service.beta.kubernetes.io/aws-load-balancer-name: mimir-ctxproxy  # Name the NLB
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 8080
      targetPort: 8080
      protocol: TCP
  selector:
    app.kubernetes.io/name: cortex-tenant
    app.kubernetes.io/instance: cortex-proxy
```
    